### PR TITLE
Fixed typo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,7 @@ export class Patreon {
                         status: Attributes.patron_status,
                         tier: {
                             id: tierInfo ? tierInfo.id : null,
-                            title: tierInfo ? tierInfo.Attributes.title : null,
+                            title: tierInfo ? tierInfo.attributes.title : null,
                         },
                         cents:
                             Attributes.currently_entitled_amount_cents != 0


### PR DESCRIPTION
`Attributes` is supposed to be `attributes`;
TypeError: Cannot read properties of undefined (reading 'title')